### PR TITLE
Add community meetings #1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add a warning for older versions that links to latest [(#54)](https://github.com/rl-institut/super-repo/pull/54)
 - Add pre-commit and setup pre-commit-hooks [(#56)](https://github.com/rl-institut/super-repo/pull/56)
 - Add a community chat on Element [(#59)](https://github.com/rl-institut/super-repo/pull/59)
+- Add documentation on the regular community meetings [(#60)](https://github.com/rl-institut/super-repo/pull/60)
 
 ### Changed
 

--- a/README.rst
+++ b/README.rst
@@ -22,7 +22,7 @@ super-repo
    * - Development
      - |badge_issue_open| |badge_issue_closes| |badge_pr_open| |badge_pr_closes|
    * - Community
-     - |badge_contributing| |badge_contributors| |badge_repo_counts| |badge_gitter|
+     - |badge_contributing| |badge_contributors| |badge_repo_counts| |badge_matrix|
 
 .. contents::
     :depth: 2
@@ -84,6 +84,6 @@ License and Citation
 .. |badge_pr_closes| image:: https://img.shields.io/github/issues-pr-closed-raw/rl-institut/super-repo
     :alt: closes issues
 
-.. |badge_gitter| image:: https://img.shields.io/matrix/super-repo:matrix.org?label=matrix%20chat
-    :target: https://app.element.io/#/room/#super-repo:matrix.org
-    :alt: Matrix Chat
+.. |badge_matrix| image:: https://img.shields.io/matrix/super-repo:matrix.org
+    :target: https://img.shields.io/matrix/super-repo%3Amatrix.org
+    :alt: Matrix

--- a/docs/development/collaboration/index.md
+++ b/docs/development/collaboration/index.md
@@ -2,3 +2,11 @@
 
 This open-source software is a collaborative effort. <br>
 The repository has several elements to provide necessary functions.
+
+To participate in the development you can do the following:
+
+- Contribute to the [GitHub Discussions](https://github.com/rl-institut/super-repo/discussions)
+- Contribute to the [GitHub Issues](https://github.com/rl-institut/super-repo/issues)
+- Follow the [workflow for collaborative development](https://github.com/rl-institut/super-repo/blob/production/CONTRIBUTING.md)
+- Get in touch with the community on the [Element Chat](https://rl-institut.github.io/super-repo/latest/development/collaboration/chat/)
+- Meet the developers in one of the [regular meetings](https://rl-institut.github.io/super-repo/latest/development/collaboration/meeting/)

--- a/docs/development/collaboration/meeting.md
+++ b/docs/development/collaboration/meeting.md
@@ -1,0 +1,24 @@
+# Meeting
+
+In order to develop a program collaboratively, it is helpful to regularly
+exchange information about the current status and to discuss open questions
+and make decisions.
+
+# Developer Meetings
+
+In the regular developer meetings, the open issues and pull requests are
+discussed and the next release is planned. There should also be time for
+the general vision of software development.
+
+The regular developer meeting `super-repo-dev` takes place on the
+**first Wednesday of the month between 9 and 9:30 am**. <br>
+The meeting room is: https://meet.jit.si/super-repo-dev
+
+# User Meetings
+
+The user meeting is specifically designed for users of the software to ask
+questions about usage, make requests for new functionality,
+or give general feedback.
+
+The regular user meeting takes place after the developer meeting in the same
+room on the **first Wednesday of the month between 9:30 and 10 am**.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -68,6 +68,7 @@ nav:
       - Contributing: development/collaboration/contributing.md
       - Users: development/collaboration/users.md
       - Chat: development/collaboration/chat.md
+      - Meetings: development/collaboration/meeting.md
       - Code of Conduct: development/collaboration/code_of_conduct.md
     - Git:
       - development/git/index.md


### PR DESCRIPTION
## Summary of the discussion

Add a documentation page on the regular community meetings.

## Type of change (CHANGELOG.md)

### Added
- Add documentation on the regular community meetings [(#60)](https://github.com/rl-institut/super-repo/pull/60)

## Workflow checklist

### Automation
Part of #1

### PR-Assignee
- [x] 🐙 Follow the workflow in [CONTRIBUTING.md](https://github.com/rl-institut/super-repo/blob/production/CONTRIBUTING.md)
- [x] 📝 Update the [CHANGELOG.md](https://github.com/rl-institut/super-repo/blob/develop/CHANGELOG.md)
- [x] 📙 Update the documentation

### Reviewer
- [ ] 🐙 Follow the [Reviewer Guidelines](https://github.com/rl-institut/super-repo/blob/production/CONTRIBUTING.md#40-let-someone-else-review-your-pr)
- [ ] 🐙 Provided feedback and show sufficient appreciation for the work done
